### PR TITLE
fix wrong argument name in example scripts

### DIFF
--- a/example_data/scripts/infer_complex.sh
+++ b/example_data/scripts/infer_complex.sh
@@ -8,8 +8,8 @@ python3 run_pretrained_opencomplex.py \
     --output_dir output/infer_result                            `# output directory` \
     --use_gpu                                                   `# use gpu inference` \
     --num_workers 1                                             `# number of parallel processes` \
-    --param_paths /path/to/ckpt                                 `# ckpt path` \
-    --config_presets "mix"                                      `# config presets as in config.py` \
+    --param_path /path/to/ckpt                                  `# ckpt path` \
+    --config_preset "mix"                                       `# config presets as in config.py` \
     --complex_type "mix"                                        `# protein, RNA, or mix (protein-RNA complex)` \
     --skip_relaxation                                           `# skip amber relaxation` \
     --overwrite                                                 `# overwrite existing result`

--- a/example_data/scripts/infer_protein.sh
+++ b/example_data/scripts/infer_protein.sh
@@ -8,8 +8,8 @@ python3 run_pretrained_opencomplex.py \
     --output_dir output/infer_result                                `# output directory` \
     --use_gpu                                                       `# use gpu inference` \
     --num_workers 1                                                 `# number of parallel processes` \
-    --param_paths /path/to/ckpt                                     `# ckpt path` \
-    --config_presets "initial_training"                             `# config presets as in config.py` \
+    --param_path /path/to/ckpt                                      `# ckpt path` \
+    --config_preset "initial_training"                              `# config presets as in config.py` \
     --complex_type "protein"                                        `# protein, RNA, or mix (protein-RNA complex)` \
     --skip_relaxation                                               `# skip amber relaxation` \
     --overwrite                                                     `# overwrite existing result`


### PR DESCRIPTION
Two misspelled arguments in infer_complex.sh and infer_protein.sh  